### PR TITLE
Upgrade Python version to 3.12 and modify install method for docs

### DIFF
--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -3,11 +3,14 @@ version: "2"
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.10"
+    python: "3.12"
 
 python:
   install:
-    - requirements: docs/requirements.txt
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs
 
 sphinx:
   configuration: docs/source/conf.py


### PR DESCRIPTION
Updated Python version and installation method in Read the Docs configuration.
- autimatically using docs requirements from pyproject.toml