### PR TITLE
Fix citation cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ title: IMAGE-materials
 version: 3.5.1.1
 identifiers:
   - type: doi
-    value: 10.5281/zenodo.19696715
+    value: 10.5281/zenodo.19696714
 abstract: >-
     The IMAGE-materials model is a stock-driven dynamic material flow analysis model,
     part of the IMAGE integrated assessment model (IAM) framework. By combining

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use IMAGE-materials model or data from it in your research, please cite it using the metadata in this cff file.
 type: software
 title: IMAGE-materials
-version: 3.5.1.0
+version: 3.5.1.1
 identifiers:
   - type: doi
     value: 10.5281/zenodo.19696715


### PR DESCRIPTION
This PR updates the version number in the citation.cff.

Additionally, it changes the DOI to use the DOI that always points to the most recent version. Now it points to a specific version (in this case 3.5.0.1), but if you want it to point to the specific version that you are releasing, you have a bit of a circularity problem, as you don't have that DOI before you create the release on Zenodo, but once the release is on Zenodo, you cannot change the citation.cff that is in there anymore. So I think having the DOI that defaults to the latest release in here makes most sense.